### PR TITLE
Add cancelAllMarketOrders

### DIFF
--- a/zeta-cpi/programs/zeta-cpi/src/lib.rs
+++ b/zeta-cpi/programs/zeta-cpi/src/lib.rs
@@ -98,6 +98,13 @@ pub mod zeta_cpi {
         )
     }
 
+    pub fn cancel_all_market_orders(ctx: Context<CancelOrderCaller>) -> Result<()> {
+        zeta_client::cancel_all_market_orders(
+            ctx.accounts.zeta_program.clone(),
+            ctx.accounts.cancel_order_cpi_accounts.clone(),
+        )
+    }
+
     pub fn read_program_data(ctx: Context<ReadProgramData>) -> Result<()> {
         let zeta_group =
             deserialize_account_info_zerocopy::<ZetaGroup>(&ctx.accounts.zeta_group).unwrap();

--- a/zeta-cpi/programs/zeta-cpi/src/zeta_client.rs
+++ b/zeta-cpi/programs/zeta-cpi/src/zeta_client.rs
@@ -99,3 +99,11 @@ pub fn cancel_order<'info>(
     let cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
     zeta_interface::cancel_order(cpi_ctx, side, order_id)
 }
+
+pub fn cancel_all_market_orders<'info>(
+    zeta_program: AccountInfo<'info>,
+    cpi_accounts: CancelOrder<'info>,
+) -> Result<()> {
+    let cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    zeta_interface::cancel_all_market_orders(cpi_ctx)
+}


### PR DESCRIPTION
This PR adds a new instruction `cancelAllMarketOrders()` that will cancel all orders on a single market index in one go using Serum's `cpi::prune()`. The only other difference between `cancelAllMarketOrders()` and `cancelOrder()` is that here we don't provide a side + order ID. 

zeta-options PR: https://github.com/zetamarkets/zeta-options/pull/472
SDK PR: https://github.com/zetamarkets/sdk/pull/157