### PR TITLE
Add seeds as an optional param for zeta_client

### DIFF
--- a/zeta-cpi/programs/zeta-cpi/src/lib.rs
+++ b/zeta-cpi/programs/zeta-cpi/src/lib.rs
@@ -25,6 +25,7 @@ pub mod zeta_cpi {
         zeta_client::initialize_margin_account(
             ctx.accounts.zeta_program.clone(),
             ctx.accounts.initialize_margin_cpi_accounts.clone(),
+            None
         )
     }
 
@@ -32,6 +33,7 @@ pub mod zeta_cpi {
         zeta_client::deposit(
             ctx.accounts.zeta_program.clone(),
             ctx.accounts.deposit_cpi_accounts.clone(),
+            None,
             amount,
         )
     }
@@ -40,6 +42,7 @@ pub mod zeta_cpi {
         zeta_client::withdraw(
             ctx.accounts.zeta_program.clone(),
             ctx.accounts.withdraw_cpi_accounts.clone(),
+            None,
             amount,
         )
     }
@@ -48,6 +51,7 @@ pub mod zeta_cpi {
         zeta_client::initialize_open_orders(
             ctx.accounts.zeta_program.clone(),
             ctx.accounts.initialize_open_orders_cpi_accounts.clone(),
+            None,
         )
     }
 
@@ -61,6 +65,7 @@ pub mod zeta_cpi {
         zeta_client::place_order(
             ctx.accounts.zeta_program.clone(),
             ctx.accounts.place_order_cpi_accounts.clone(),
+            None,
             price,
             size,
             side,
@@ -80,6 +85,7 @@ pub mod zeta_cpi {
         zeta_client::place_order_v3(
             ctx.accounts.zeta_program.clone(),
             ctx.accounts.place_order_cpi_accounts.clone(),
+            None,
             price,
             size,
             side,
@@ -93,6 +99,7 @@ pub mod zeta_cpi {
         zeta_client::cancel_order(
             ctx.accounts.zeta_program.clone(),
             ctx.accounts.cancel_order_cpi_accounts.clone(),
+            None,
             side,
             order_id,
         )
@@ -102,6 +109,7 @@ pub mod zeta_cpi {
         zeta_client::cancel_all_market_orders(
             ctx.accounts.zeta_program.clone(),
             ctx.accounts.cancel_order_cpi_accounts.clone(),
+            None,
         )
     }
 
@@ -181,8 +189,6 @@ pub mod zeta_cpi {
         let margin_account =
             deserialize_account_info_zerocopy::<MarginAccount>(&ctx.accounts.margin_account)
                 .unwrap();
-
-        msg!("Margin account balance: {:?}", margin_account.balance);
 
         // Position details for a given market index.
         let size = margin_account.product_ledgers[market_index].position.size;

--- a/zeta-cpi/programs/zeta-cpi/src/zeta_client.rs
+++ b/zeta-cpi/programs/zeta-cpi/src/zeta_client.rs
@@ -28,57 +28,79 @@ pub trait ZetaInterface<'info, T: Accounts<'info>> {
         tag: Option<String>,
     ) -> Result<()>;
     fn cancel_order(ctx: Context<T>, side: Side, order_id: u128) -> Result<()>;
+    fn cancel_all_market_orders(ctx: Context<T>) -> Result<()>;
 }
 
 pub fn initialize_margin_account<'info>(
     zeta_program: AccountInfo<'info>,
     cpi_accounts: InitializeMarginAccount<'info>,
+    signer_seeds: Option<&[&[&[u8]]]>,
 ) -> Result<()> {
-    let cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    let mut cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    if let Some(seeds) = signer_seeds {
+        cpi_ctx = cpi_ctx.with_signer(seeds);
+    }
     zeta_interface::initialize_margin_account(cpi_ctx)
 }
 
 pub fn deposit<'info>(
     zeta_program: AccountInfo<'info>,
     cpi_accounts: Deposit<'info>,
+    signer_seeds: Option<&[&[&[u8]]]>,
     amount: u64,
 ) -> Result<()> {
-    let cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    let mut cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    if let Some(seeds) = signer_seeds {
+        cpi_ctx = cpi_ctx.with_signer(seeds);
+    }
     zeta_interface::deposit(cpi_ctx, amount)
 }
 
 pub fn withdraw<'info>(
     zeta_program: AccountInfo<'info>,
     cpi_accounts: Withdraw<'info>,
+    signer_seeds: Option<&[&[&[u8]]]>,
     amount: u64,
 ) -> Result<()> {
-    let cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    let mut cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    if let Some(seeds) = signer_seeds {
+        cpi_ctx = cpi_ctx.with_signer(seeds);
+    }
     zeta_interface::withdraw(cpi_ctx, amount)
 }
 
 pub fn initialize_open_orders<'info>(
     zeta_program: AccountInfo<'info>,
     cpi_accounts: InitializeOpenOrders<'info>,
+    signer_seeds: Option<&[&[&[u8]]]>,
 ) -> Result<()> {
-    let cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    let mut cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    if let Some(seeds) = signer_seeds {
+        cpi_ctx = cpi_ctx.with_signer(seeds);
+    }
     zeta_interface::initialize_open_orders(cpi_ctx)
 }
 
 pub fn place_order<'info>(
     zeta_program: AccountInfo<'info>,
     cpi_accounts: PlaceOrder<'info>,
+    signer_seeds: Option<&[&[&[u8]]]>,
     price: u64,
     size: u64,
     side: Side,
     client_order_id: Option<u64>,
 ) -> Result<()> {
-    let cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    let mut cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    if let Some(seeds) = signer_seeds {
+        cpi_ctx = cpi_ctx.with_signer(seeds);
+    }
     zeta_interface::place_order(cpi_ctx, price, size, side, client_order_id)
 }
 
 pub fn place_order_v3<'info>(
     zeta_program: AccountInfo<'info>,
     cpi_accounts: PlaceOrder<'info>,
+    signer_seeds: Option<&[&[&[u8]]]>,
     price: u64,
     size: u64,
     side: Side,
@@ -86,24 +108,35 @@ pub fn place_order_v3<'info>(
     client_order_id: Option<u64>,
     tag: Option<String>, // Not stored, only used when sniffing the transactions
 ) -> Result<()> {
-    let cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    let mut cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    if let Some(seeds) = signer_seeds {
+        cpi_ctx = cpi_ctx.with_signer(seeds);
+    }
     zeta_interface::place_order_v3(cpi_ctx, price, size, side, order_type, client_order_id, tag)
 }
 
 pub fn cancel_order<'info>(
     zeta_program: AccountInfo<'info>,
     cpi_accounts: CancelOrder<'info>,
+    signer_seeds: Option<&[&[&[u8]]]>,
     side: Side,
     order_id: u128,
 ) -> Result<()> {
-    let cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    let mut cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    if let Some(seeds) = signer_seeds {
+        cpi_ctx = cpi_ctx.with_signer(seeds);
+    }
     zeta_interface::cancel_order(cpi_ctx, side, order_id)
 }
 
 pub fn cancel_all_market_orders<'info>(
     zeta_program: AccountInfo<'info>,
     cpi_accounts: CancelOrder<'info>,
+    signer_seeds: Option<&[&[&[u8]]]>,
 ) -> Result<()> {
-    let cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    let mut cpi_ctx = CpiContext::new(zeta_program, cpi_accounts);
+    if let Some(seeds) = signer_seeds {
+        cpi_ctx = cpi_ctx.with_signer(seeds);
+    }
     zeta_interface::cancel_all_market_orders(cpi_ctx)
 }


### PR DESCRIPTION
* Adds seeds as an optional param for zeta_client functions, to allow cross-program invocations where a PDA is the authority.
* Removed `msg!("Margin account balance: {:?}", margin_account.balance);` print statement which was causing a `reference to packed field is unaligned` error
* Fix compilation error caused by `cancel_all_market_orders` not being defined in `ZetaInterface`